### PR TITLE
Fix builder import bug

### DIFF
--- a/Payload_Type/Kassandra/Kassandra/agent_functions/builder.py
+++ b/Payload_Type/Kassandra/Kassandra/agent_functions/builder.py
@@ -8,6 +8,7 @@ from distutils.dir_util import copy_tree
 import asyncio
 import os
 import time
+import base64
 import subprocess
 
 class KassandraAgent(PayloadType):


### PR DESCRIPTION
## Summary
- add missing `base64` import used for decoding C2 profile parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409cf80bc083298e207093c0cf6b2f