### PR TITLE
Fix: remove stray comment

### DIFF
--- a/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/src/features/filesystem.rs
+++ b/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/src/features/filesystem.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::Path;
-use std::io::Write; // <- Add this
+use std::io::Write;
 
 pub fn handle_fs_command(task: &serde_json::Value) -> Result<(), Box<dyn std::error::Error>> {
     let command = task.get("command")


### PR DESCRIPTION
## Summary
- remove leftover comment in filesystem feature

## Testing
- `cargo check` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68409e1ce3fc8329a062a8d6a527b084