### PR TITLE
Fix process description typo

### DIFF
--- a/Payload_Type/Kassandra/Kassandra/agent_functions/psw.py
+++ b/Payload_Type/Kassandra/Kassandra/agent_functions/psw.py
@@ -20,7 +20,7 @@ class PSCommand(CommandBase):
     cmd = "ps"
     needs_admin = False
     help_cmd = "ps"
-    description = "Get all Procsses information"
+    description = "Get all Processes information"
     version = 1
     author = "@PatchRequest"
     attackmapping = ["T1083"]


### PR DESCRIPTION
## Summary
- fix typo in `psw` command description

## Testing
- `python3 -m py_compile Payload_Type/Kassandra/Kassandra/agent_functions/psw.py`


------
https://chatgpt.com/codex/tasks/task_e_68409e1e0110832987ff3992683f7d1d