### PR TITLE
chore: switch coffee-ldr back to upstream

### DIFF
--- a/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/Cargo.lock
+++ b/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "coffee-ldr"
 version = "0.2.2"
-source = "git+https://github.com/PatchRequest/coffee?branch=main#f679a26647f6fd48f32423e18537c9d56e9348fd"
+source = "git+https://github.com/hakaioffsec/coffee?branch=main#f679a26647f6fd48f32423e18537c9d56e9348fd"
 dependencies = [
  "base64",
  "byteorder",

--- a/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/Cargo.toml
+++ b/Payload_Type/Kassandra/Kassandra/agent_code/kassandra/Cargo.toml
@@ -19,7 +19,7 @@ uuid = { version = "1", features = ["v4"] }
 aes = "0.8"
 getrandom = "0.2"
 lazy_static = "1.5.0"
-coffee-ldr = { git = "https://github.com/PatchRequest/coffee", branch = "main" }
+coffee-ldr = { git = "https://github.com/hakaioffsec/coffee", branch = "main" }
 windows-sys = { version = "0.48", features = [
   "Win32_System_Threading",
   "Win32_Foundation",


### PR DESCRIPTION
## Summary
- switch `coffee-ldr` from the forked `PatchRequest/coffee` dependency back to upstream `hakaioffsec/coffee`
- keep tracking `main`
- update `Cargo.lock` to reflect the new source

## Why
The upstream `coffee` repository now contains the required fix, so Kassandra no longer needs to depend on the fork.